### PR TITLE
feat(side-sheet): make emotion a dev dependency

### DIFF
--- a/.jest-test-results.json
+++ b/.jest-test-results.json
@@ -25,7 +25,7 @@
     "unmatched": 0,
     "updated": 0
   },
-  "startTime": 1554617889751,
+  "startTime": 1555389244104,
   "success": true,
   "testResults": [
     {
@@ -39,10 +39,10 @@
           "title": "renders without exploding"
         }
       ],
-      "endTime": 1554617891347,
+      "endTime": 1555389246993,
       "message": "",
-      "name": "/Users/elanhant/work/jeeves/packages/side-sheet/src/__tests__/Scrim.test.tsx",
-      "startTime": 1554617890796,
+      "name": "C:\\Git\\react-jeeves\\packages\\side-sheet\\src\\__tests__\\Scrim.test.tsx",
+      "startTime": 1555389245156,
       "status": "passed",
       "summary": ""
     }

--- a/packages/side-sheet/package.json
+++ b/packages/side-sheet/package.json
@@ -37,10 +37,10 @@
     "url": "https://github.com/Elanhant/react-jeeves/issues"
   },
   "dependencies": {
-    "@emotion/core": "^10.0.10",
     "react-spring": "^8.0.19"
   },
   "devDependencies": {
+    "@emotion/core": "^10.0.10",
     "rollup": "^1.9.0",
     "rollup-plugin-cleaner": "^0.2.0",
     "rollup-plugin-typescript2": "^0.20.1",

--- a/packages/side-sheet/src/components/Scrim.tsx
+++ b/packages/side-sheet/src/components/Scrim.tsx
@@ -1,37 +1,27 @@
 import React from 'react';
-import { css } from '@emotion/core';
 import { animated, AnimatedValue } from 'react-spring';
 import useSideSheetContext from '../hooks/useSideSheetContext';
 import useTabTrap, { TrapElement } from '../hooks/useTabTrap';
-
-const baseCss = css`
-  transform: none !important; // react-spring may try to set transform style which we don't need
-
-  &:before {
-    content: ' ';
-    display: block;
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.42);
-  }
-`;
 
 export type ScrimProps = {
   children: React.ReactNode;
   style?: AnimatedValue<any>;
   sideSheetRef?: TrapElement;
+  className?: string;
 };
 
-export default function Scrim({ children, style, sideSheetRef }: ScrimProps) {
+export default function Scrim({
+  children,
+  style,
+  sideSheetRef,
+  className,
+}: ScrimProps) {
   const { close } = useSideSheetContext();
 
   useTabTrap(sideSheetRef, close);
 
   return (
-    <animated.div css={baseCss} style={style} onClick={close}>
+    <animated.div className={className} style={style} onClick={close}>
       {children}
     </animated.div>
   );

--- a/packages/side-sheet/src/components/SideSheet.tsx
+++ b/packages/side-sheet/src/components/SideSheet.tsx
@@ -1,25 +1,9 @@
 import React from 'react';
-import { css } from '@emotion/core';
 import { useTransition, UseTransitionResult, animated } from 'react-spring';
 import SideSheetProvider from './Provider';
 import Scrim from './Scrim';
 
-const containerCss = css`
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-`;
-
-const baseCss = css`
-  position: absolute;
-  max-width: 100vw;
-  height: 100vh;
-  right: 0;
-`;
-
-const transitionConfig = {
+const defaultTransitionConfig = {
   from: { opacity: 0, transform: 'translate3d(100%, 0, 0)' },
   enter: { opacity: 1, transform: 'translate3d(0, 0, 0)' },
   leave: { opacity: 0, transform: 'translate3d(100%, 0, 0)' },
@@ -29,12 +13,20 @@ export type SideSheetProps = {
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  containerClassName?: string;
+  scrimClassName?: string;
+  sheetClassName?: string;
+  transitionConfig?: Record<string, any>;
 };
 
 export default function SideSheet({
   isOpen,
   onClose,
   children,
+  containerClassName,
+  scrimClassName,
+  sheetClassName,
+  transitionConfig = defaultTransitionConfig,
 }: SideSheetProps) {
   const tabTrapRef = React.useRef<HTMLDivElement>(null);
 
@@ -46,10 +38,14 @@ export default function SideSheet({
     }: UseTransitionResult<boolean, any>) => {
       return (
         shouldDisplaySheet && (
-          <div css={containerCss} key={key}>
-            <Scrim style={props} sideSheetRef={tabTrapRef.current}>
+          <div className={containerClassName} key={key}>
+            <Scrim
+              style={props}
+              sideSheetRef={tabTrapRef.current}
+              className={scrimClassName}
+            >
               <animated.div
-                css={baseCss}
+                className={sheetClassName}
                 style={props}
                 onClick={stopPropagation}
                 ref={tabTrapRef}
@@ -61,7 +57,7 @@ export default function SideSheet({
         )
       );
     },
-    [children, tabTrapRef],
+    [children, tabTrapRef, containerClassName, scrimClassName, sheetClassName],
   );
 
   const transitions = useTransition(isOpen, null, transitionConfig);

--- a/packages/side-sheet/src/stories/index.stories.tsx
+++ b/packages/side-sheet/src/stories/index.stories.tsx
@@ -1,9 +1,39 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { css } from '@emotion/core';
+import { css, ClassNames } from '@emotion/core';
 import useSideSheet from '../hooks/useSideSheet';
 import SideSheet from '../components/SideSheet';
+
+const containerCss = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+`;
+
+const scrimCss = css`
+  transform: none !important; // react-spring may try to set transform style which we don't need
+
+  &:before {
+    content: ' ';
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.42);
+  }
+`;
+
+const sheetCss = css`
+  position: absolute;
+  max-width: 100vw;
+  height: 100vh;
+  right: 0;
+`;
 
 storiesOf('side-sheet', module)
   .add('Default', () => {
@@ -108,7 +138,20 @@ function TestComponent({ children }: { children: React.ReactNode }) {
   return (
     <React.Fragment>
       <button onClick={open}>Open side sheet</button>
-      <SideSheet {...sideSheetProps}>{children}</SideSheet>
+      <ClassNames>
+        {({ css: cxCss }) => {
+          return (
+            <SideSheet
+              {...sideSheetProps}
+              containerClassName={cxCss(containerCss)}
+              scrimClassName={cxCss(scrimCss)}
+              sheetClassName={cxCss(sheetCss)}
+            >
+              {children}
+            </SideSheet>
+          );
+        }}
+      </ClassNames>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
It is probably better to not force users to depend on emotion for side sheet styling. Added the following props to allow CSS customization:
* `containerClassName` - class name for the root div
* `scrimClassName` - class name for the scrim div
* `sheetClassName` - class name for the sheet div