### PR TITLE
fix(side-sheet): fix dependency version for react-jeeves-hooks

### DIFF
--- a/.jest-test-results.json
+++ b/.jest-test-results.json
@@ -25,7 +25,7 @@
     "unmatched": 0,
     "updated": 0
   },
-  "startTime": 1562553112874,
+  "startTime": 1571767310322,
   "success": true,
   "testResults": [
     {
@@ -39,10 +39,10 @@
           "title": "renders without exploding"
         }
       ],
-      "endTime": 1562553114444,
+      "endTime": 1571767312048,
       "message": "",
-      "name": "/Users/elanhant/work/jeeves/packages/side-sheet/src/__tests__/Scrim.test.tsx",
-      "startTime": 1562553113895,
+      "name": "/Users/aleksei/work/react-jeeves/packages/side-sheet/src/__tests__/Scrim.test.tsx",
+      "startTime": 1571767311062,
       "status": "passed",
       "summary": ""
     }

--- a/packages/side-sheet/package.json
+++ b/packages/side-sheet/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/Elanhant/react-jeeves/issues"
   },
   "dependencies": {
-    "react-jeeves-hooks": "^0.0.1",
+    "react-jeeves-hooks": "*",
     "react-spring": "^8.0.19"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10488,9 +10488,6 @@ react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-jeeves-hooks@^0.0.1:
-  version "0.1.1"
-
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"


### PR DESCRIPTION
Fixes the issue that occurs when trying to install `react-jeeves-side-sheet`:

>Couldn't find any versions for "react-jeeves-hooks" that matches "^0.0.1"
> ? Please choose a version of "react-jeeves-hooks" from this list: (Use arrow keys)
> \> 0.1.1